### PR TITLE
Update create and comment actions

### DIFF
--- a/workflow-templates/jira.yaml
+++ b/workflow-templates/jira.yaml
@@ -48,12 +48,12 @@ jobs:
 
     - name: Create ticket
       if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
-      uses: tomhjp/gh-action-jira-create@v0.1.0
+      uses: tomhjp/gh-action-jira-create@v0.1.3
       with:
         project: VAULT
         issuetype: "GH Issue"
         summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
-        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }}, from ${{ github.actor }}_"
+        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field
         extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["product"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
@@ -68,7 +68,7 @@ jobs:
 
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: atlassian/gajira-comment@v2.0.1
+      uses: tomhjp/gh-action-jira-comment@v0.1.0
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"


### PR DESCRIPTION
- The action now supports converting the most common bits of markdown syntax into Jira formatting directives
- Remove trailing comma after link that meant Jira messed up the URL to link to
- Stop using Atlassian's comment action, which has the most inexplicable "feature" to interpolate bits of text wrapped in {{}} (and often just cause failures).

This is an example of the `m2j` formatting in action: https://hashicorp.atlassian.net/browse/VAULT-583. I've tested the rest in my own Jira instance.