### PR TITLE
Update Jira sync workflow to use pandoc

### DIFF
--- a/workflow-templates/jira.yaml
+++ b/workflow-templates/jira.yaml
@@ -48,9 +48,9 @@ jobs:
         # Run GitHub flavored (gfm) markdown through pandoc to convert to jira markdown
         # Then replace newlines with %0A so that newlines get preserved when storing in the step output
         # The %0A will then get expanded back to real new lines when the output is included in a later step inside $ {{}} syntax
-        BODY="$(cat <<"EOF" | docker run -i --rm pandoc/core:2.11.0.4 --from gfm --to jira | awk '{printf "%s%%0A", $0}'
+        BODY="$(cat <<"EOF-PandocInput" | docker run -i --rm pandoc/core:2.11.0.4 --from gfm --to jira | awk '{printf "%s%%0A", $0}'
         ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || github.event.pull_request.body }}
-        EOF
+        EOF-PandocInput
         )"
         echo "::set-output name=body::${BODY}"
     - name: Create ticket

--- a/workflow-templates/jira.yaml
+++ b/workflow-templates/jira.yaml
@@ -5,7 +5,6 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
-  workflow_dispatch:
 
 name: Jira Sync
 
@@ -36,9 +35,9 @@ jobs:
         JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
 
-    - name: Set ticket type
-      if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
-      id: set-ticket-type
+    - name: Preprocess
+      if: github.event.action == 'opened' || github.event.action == 'created'
+      id: preprocess
       run: |
         if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
           echo "::set-output name=type::PR"
@@ -46,14 +45,22 @@ jobs:
           echo "::set-output name=type::ISS"
         fi
 
+        # Run GitHub flavored (gfm) markdown through pandoc to convert to jira markdown
+        # Then replace newlines with %0A so that newlines get preserved when storing in the step output
+        # The %0A will then get expanded back to real new lines when the output is included in a later step inside $ {{}} syntax
+        BODY="$(cat <<"EOF" | docker run -i --rm pandoc/core:2.11.0.4 --from gfm --to jira | awk '{printf "%s%%0A", $0}'
+        ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || github.event.pull_request.body }}
+        EOF
+        )"
+        echo "::set-output name=body::${BODY}"
     - name: Create ticket
       if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
-      uses: tomhjp/gh-action-jira-create@v0.1.3
+      uses: tomhjp/gh-action-jira-create@v0.1.4
       with:
         project: VAULT
         issuetype: "GH Issue"
-        summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
-        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
+        summary: "${{ github.event.repository.name }} [${{ steps.preprocess.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
+        description: "${{ steps.preprocess.outputs.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field
         extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["product"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
@@ -68,10 +75,10 @@ jobs:
 
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: tomhjp/gh-action-jira-comment@v0.1.0
+      uses: tomhjp/gh-action-jira-comment@v0.1.1
       with:
         issue: ${{ steps.search.outputs.issue }}
-        comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
+        comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ steps.preprocess.outputs.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
 
     - name: Close ticket
       if: (github.event.action == 'closed' || github.event.action == 'deleted') && steps.search.outputs.issue


### PR DESCRIPTION
Rather than writing our own GitHub -> Jira markdown conversion, we can use pandoc, which should be much less buggy and better maintained. Previously the conversion was baked into the create/comment GitHub actions, so I've released new versions of those that don't do any formatting of the input.